### PR TITLE
Fix langcode synchronization

### DIFF
--- a/src/EventSubscriber/MauticSubscriber.php
+++ b/src/EventSubscriber/MauticSubscriber.php
@@ -69,7 +69,7 @@ class MauticSubscriber implements EventSubscriberInterface {
         "firstname" => ($base_address) ? $base_address['given_name'] : "",
         "lastname" => ($base_address) ? $base_address['family_name'] : "",
         "token" => $user->field_iq_group_user_token->value,
-        "preferred_locale" => $user->langcode->value,
+        "preferred_locale" => $user->preferred_langcode->value,
       ];
 
       // Add tags data if available.


### PR DESCRIPTION
Currently the language of the user is imported by the `langcode` of the user's entity instead of the actual language preference of the user in `preferred_langcode`. Since the frontend and the import relies on the latter, this should be changed accordingly.

This re-applies a fix from `v1.3` (38cdee904fc05ec55ca97a802d51bb26d5e9a5f9) which got lost in `v2.0`.